### PR TITLE
Add slerp and override getattr method

### DIFF
--- a/examples/manifold_optimization.py
+++ b/examples/manifold_optimization.py
@@ -5,6 +5,8 @@
 # conda install matplotlib scipy
 
 import casadi as cs
+import matplotlib
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import animation
@@ -25,13 +27,13 @@ dt = T / N
 for k in range(N):
     vector_SO3 = SO3Tangent(vel[k] * dt)
     rotation_SO3 = SO3(quat[k])
-    opti.subject_to(quat[k + 1] == (vector_SO3 + rotation_SO3).as_quat().coeffs())
+    opti.subject_to(quat[k + 1] == (vector_SO3 + rotation_SO3).as_quat())
 
 
 C = sum(cs.sumsqr(vel[i]) for i in range(N)) + T
 
 # Initial rotation and velocity
-opti.subject_to(quat[0] == SO3.Identity().as_quat().coeffs())
+opti.subject_to(quat[0] == SO3.Identity().as_quat())
 opti.subject_to(vel[0] == 0)
 opti.subject_to(opti.bounded(0, T, 10))
 
@@ -47,7 +49,7 @@ for k in range(N):
 opti.subject_to(vel[N - 1] == 0)
 final_delta_increment = SO3Tangent([cs.pi / 3, cs.pi / 6, cs.pi / 2])
 
-opti.subject_to(quat[N] == (final_delta_increment + SO3.Identity()).as_quat().coeffs())
+opti.subject_to(quat[N] == (final_delta_increment + SO3.Identity()).as_quat())
 
 opti.minimize(C)
 
@@ -71,7 +73,8 @@ plt.suptitle("Velocity")
 plt.plot(np.linspace(0, time, N), v)
 
 figure = plt.figure()
-axes = mplot3d.Axes3D(figure)
+axes = figure.add_subplot(projection="3d")
+
 x_cords = np.array([1, 0, 0])
 y_cords = np.array([0, 1, 0])
 z_cords = np.array([0, 0, 1])

--- a/examples/slerp_so3.py
+++ b/examples/slerp_so3.py
@@ -1,0 +1,90 @@
+# Please note that for running this example you need to install `matplotlib` and `scipy`.
+# You can do this by running the following command in your terminal:
+# pip install matplotlib scipy
+# If you are using anaconda, you can also run the following command:
+# conda install matplotlib scipy
+
+import casadi as cs
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import animation
+
+from liecasadi import SO3, SO3Tangent
+
+N = 10
+
+r1 = SO3.Identity()
+
+final_delta_increment = SO3Tangent([cs.pi / 3, cs.pi / 6, cs.pi / 2])
+
+r2 = final_delta_increment + SO3.Identity()
+
+x = SO3.slerp(r1, r2, N)
+
+# If you want to work directly with quaternion, you can use the following code:
+# x = Quaternion.slerp(q1, q1, N)
+# where q1 and q2 are Quaternion objects.
+
+figure = plt.figure()
+axes = figure.add_subplot(projection="3d")
+x_cords = np.array([1, 0, 0])
+y_cords = np.array([0, 1, 0])
+z_cords = np.array([0, 0, 1])
+
+axes.set_box_aspect((1, 1, 1))
+
+(xax,) = axes.plot([0, 1], [0, 0], [0, 0], "red")
+(yax,) = axes.plot([0, 0], [0, 1], [0, 0], "green")
+(zax,) = axes.plot([0, 0], [0, 0], [0, 1], "blue")
+
+print("qui", x[N - 1].act(x_cords))
+
+# final orientation
+x_N = np.array(x[N - 1].act(x_cords)).reshape(
+    3,
+)
+y_N = np.array(x[N - 1].act(y_cords)).reshape(
+    3,
+)
+z_N = np.array(x[N - 1].act(z_cords)).reshape(
+    3,
+)
+
+(xaxN,) = axes.plot([0, x_N[0]], [0, x_N[1]], [0, x_N[2]], "red")
+(yaxN,) = axes.plot([0, y_N[0]], [0, y_N[1]], [0, y_N[2]], "green")
+(zaxN,) = axes.plot([0, z_N[0]], [0, z_N[1]], [0, z_N[2]], "blue")
+
+
+def update_points(i):
+    x_i = np.array(x[i].act(x_cords)).reshape(
+        3,
+    )
+    y_i = np.array(x[i].act(y_cords)).reshape(
+        3,
+    )
+    z_i = np.array(x[i].act(z_cords)).reshape(
+        3,
+    )
+    # update properties
+    xax.set_data(np.array([[0, x_i[0]], [0, x_i[1]]]))
+    xax.set_3d_properties(np.array([0, x_i[2]]), "z")
+
+    yax.set_data(np.array([[0, y_i[0]], [0, y_i[1]]]))
+    yax.set_3d_properties(np.array([0, y_i[2]]), "z")
+
+    zax.set_data(np.array([[0, z_i[0]], [0, z_i[1]]]))
+    zax.set_3d_properties(np.array([0, z_i[2]]), "z")
+
+    # return modified axis
+    return (
+        xax,
+        yax,
+        zax,
+    )
+
+
+ani = animation.FuncAnimation(figure, update_points, frames=N, repeat=False)
+writergif = animation.PillowWriter(fps=5)
+ani.save("animation.gif", writer=writergif)
+
+plt.show()

--- a/src/liecasadi/quaternion.py
+++ b/src/liecasadi/quaternion.py
@@ -88,7 +88,7 @@ class Quaternion:
         return self.conjugate() / cs.dot(self.xyzw, self.xyzw)
 
     @staticmethod
-    def slerp(q1: "Quaternion", q2: "Quaternion", n: Scalar) -> List[Vector]:
+    def slerp(q1: "Quaternion", q2: "Quaternion", n: Scalar) -> List["Quaternion"]:
         """Spherical linear interpolation between two quaternions
         check https://en.wikipedia.org/wiki/Slerp for more details
 
@@ -98,11 +98,11 @@ class Quaternion:
             n (Scalar): Number of interpolation steps
 
         Returns:
-            Quaternion: Interpolated quaternion
+            List[Quaternion]: Interpolated quaternion
         """
         q1 = q1.coeffs()
         q2 = q2.coeffs()
-        return [Quaternion.slerp_step(q1, q2, t) for t in cs.np.linspace(0, 1, n + 1)]
+        return [Quaternion.slerp_step(q1, q2, t) for t in cs.np.linspace(0, 1, n)]
 
     @staticmethod
     def slerp_step(q1: Vector, q2: Vector, t: Scalar) -> Vector:
@@ -119,4 +119,6 @@ class Quaternion:
 
         dot = cs.dot(q1, q2)
         angle = cs.acos(dot)
-        return (cs.sin((1.0 - t) * angle) * q1 + cs.sin(t * angle) * q2) / cs.sin(angle)
+        return Quaternion(
+            (cs.sin((1.0 - t) * angle) * q1 + cs.sin(t * angle) * q2) / cs.sin(angle)
+        )

--- a/src/liecasadi/quaternion.py
+++ b/src/liecasadi/quaternion.py
@@ -14,6 +14,9 @@ from liecasadi.hints import Scalar, Vector
 class Quaternion:
     xyzw: Vector
 
+    def __getattr__(self, attr):
+        return getattr(self.xyzw, attr)
+
     def __repr__(self) -> str:
         return f"Quaternion: {self.xyzw}"
 

--- a/src/liecasadi/so3.py
+++ b/src/liecasadi/so3.py
@@ -4,7 +4,7 @@
 
 import dataclasses
 from dataclasses import field
-from typing import Union
+from typing import Union, List
 
 import casadi as cs
 import numpy as np
@@ -116,7 +116,6 @@ class SO3:
         omega_in_body_fixed: bool = False,
         baumgarte_coefficient: Union[float, None] = None,
     ):
-
         if baumgarte_coefficient is not None:
             baumgarte_term = (
                 baumgarte_coefficient
@@ -139,10 +138,22 @@ class SO3:
         ).coeffs()
 
     @staticmethod
-    def product(q1: Vector, q2: Vector) -> Vector:
-        p1 = q1[3] * q2[3] - cs.dot(q1[:3], q2[:3])
-        p2 = q1[3] * q2[:3] + q2[3] * q1[:3] + cs.cross(q1[:3], q2[:3])
-        return cs.vertcat(p2, p1)
+    def slerp(r1: "SO3", r2: "SO3", n: int) -> List["SO3"]:
+        """
+        Spherical linear interpolation between two rotations.
+
+        Args:
+            r1 (SO3): First quaternion
+            r2 (SO3): Second quaternion
+            n (Scalar): Number of interpolation steps
+
+        Returns:
+            List[SO3]: Interpolated rotations
+        """
+        q1 = r1.as_quat()
+        q2 = r2.as_quat()
+        interpolated_quats = Quaternion.slerp(q1, q2, n)
+        return [SO3(xyzw=q.coeffs()) for q in interpolated_quats]
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
This PR introduces the slerp method.
See the example `slerp_so3` to check how it works.

Also, I introduced a small modification that would allow passing directly `Quaternion` objects to casadi methods without accessing the quaternion coefficients with `.coeffs()`:
```python
    def __getattr__(self, attr):
        return getattr(self.xyzw, attr)
```
This modification should give to the Quaternion class methods from the underlying type that is used to build a Quaternion instance.

For example, before:
```python
opti.subject_to(quat[k + 1] == (rotation_SO3[k+1]).as_quat().coeffs())
# or
opti.subject_to(quat[k + 1] == (quaternion_obj[k+1]).coeffs())
```
Now:
```python
opti.subject_to(quat[k + 1] == (rotation_SO3[k+1]).as_quat())
# or
opti.subject_to(quat[k + 1] == (quaternion_obj[k]))
```

This modification shouldn't break the previous code since the `.coeffs()` method is still accessible.

A lot of doc is still missing! I'll add it in a different PR.
