### PR TITLE
[SLERP] Return the first quaternion when the two quaternion are equal

### DIFF
--- a/src/liecasadi/quaternion.py
+++ b/src/liecasadi/quaternion.py
@@ -122,6 +122,12 @@ class Quaternion:
 
         dot = cs.dot(q1, q2)
         angle = cs.acos(dot)
+        # if the angle is small (meaning the quaternions are "equal") we return the first quaternion
         return Quaternion(
-            (cs.sin((1.0 - t) * angle) * q1 + cs.sin(t * angle) * q2) / cs.sin(angle)
+            cs.if_else(
+                angle < 1e-6,
+                q1,
+                (cs.sin((1.0 - t) * angle) * q1 + cs.sin(t * angle) * q2)
+                / cs.sin(angle),
+            )
         )


### PR DESCRIPTION
This PR fixes #12. 
Now the the `slerp_step` method returns the quaternion `q1` when interpolating between `q1` and `q2` **if** these two quaternions are equal (or approximately equal).